### PR TITLE
docs: Elevate GitHub permissions to all workflow examples

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,6 +19,9 @@ on:
 jobs:
   update-asana-task:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - name: Sync PR to Asana
         uses: planningcenter/asana-github-sync@main
@@ -75,6 +78,9 @@ on:
 jobs:
   update-asana-field:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - name: Sync PR to Asana
         uses: planningcenter/asana-github-sync@main
@@ -127,6 +133,9 @@ on:
 jobs:
   create-asana-task:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - name: Sync PR to Asana
         uses: planningcenter/asana-github-sync@main
@@ -212,6 +221,9 @@ on:
 jobs:
   create-asana-task:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - name: Sync PR to Asana
         uses: planningcenter/asana-github-sync@main

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: actions/checkout@v6
       - uses: planningcenter/asana-github-sync@main

--- a/docs/examples/basic-status-update.md
+++ b/docs/examples/basic-status-update.md
@@ -17,6 +17,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/examples/bot-task-creation.md
+++ b/docs/examples/bot-task-creation.md
@@ -20,6 +20,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/examples/build-label-automation.md
+++ b/docs/examples/build-label-automation.md
@@ -20,6 +20,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/examples/mark-complete-on-merge.md
+++ b/docs/examples/mark-complete-on-merge.md
@@ -21,6 +21,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/examples/multi-condition-filtering.md
+++ b/docs/examples/multi-condition-filtering.md
@@ -22,6 +22,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/examples/user-assigned-tasks.md
+++ b/docs/examples/user-assigned-tasks.md
@@ -20,6 +20,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -39,6 +39,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -59,6 +59,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/guide/your-first-rule.md
+++ b/docs/guide/your-first-rule.md
@@ -34,6 +34,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,9 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write  # For posting comments
+      contents: read        # For reading PR data
     steps:
       - uses: planningcenter/asana-github-sync@main
         with:


### PR DESCRIPTION
Add explicit pull-requests and contents permissions to all GitHub Actions workflow examples throughout the documentation.

## Problem
The action was failing in downstream projects (e.g., ChurchCenterApp) when trying to post comments to PRs because the necessary GitHub permissions were not explicitly configured in the workflow examples.

See: https://github.com/planningcenter/ChurchCenterApp/actions/runs/21845368960/job/63039860783
Related PR: https://github.com/planningcenter/ChurchCenterApp/pull/4716

## Solution
Added the required permissions block to all workflow examples:
```yaml
permissions:
  pull-requests: write  # For posting comments
  contents: read        # For reading PR data
```

## Changes
- README.md basic usage
- Installation guide
- Your First Rule guide
- 6 example workflows
- 4 migration workflows
- Documentation homepage

These permissions are now prominently featured across all documentation to prevent similar issues in the future.