### PR TITLE
Add GitHub issues support

### DIFF
--- a/__tests__/rules/engine.test.ts
+++ b/__tests__/rules/engine.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, test, expect, beforeEach, beforeAll, spyOn } from 'bun:test';
 import * as core from '@actions/core';
-import { matchesCondition, executeRules, RuleContext } from '../../src/rules/engine';
+import { matchesCondition, executeRules, buildRuleContext, RuleContext } from '../../src/rules/engine';
 import { Rule, Condition } from '../../src/rules/types';
 
 // Create spies for @actions/core
@@ -80,7 +80,7 @@ describe('matchesCondition', () => {
   });
 
   test('matches merged PR', () => {
-    baseContext.pr.merged = true;
+    baseContext = { ...baseContext, pr: { ...baseContext.pr!, merged: true } };
     const condition: Condition = { event: 'pull_request', merged: true };
     expect(matchesCondition(condition, baseContext)).toBe(true);
   });
@@ -96,7 +96,7 @@ describe('matchesCondition', () => {
   });
 
   test('matches draft PR', () => {
-    baseContext.pr.draft = true;
+    baseContext = { ...baseContext, pr: { ...baseContext.pr!, draft: true } };
     const condition: Condition = { event: 'pull_request', draft: true };
     expect(matchesCondition(condition, baseContext)).toBe(true);
   });
@@ -338,5 +338,288 @@ describe('executeRules', () => {
     const { fieldUpdates } = executeRules(rules, baseContext);
 
     expect(fieldUpdates.size).toBe(0);
+  });
+});
+
+// ── Issues event support ──────────────────────────────────────────────────────
+
+describe('matchesCondition - issues event', () => {
+  let issueContext: RuleContext;
+
+  beforeEach(() => {
+    infoSpy.mockClear();
+    errorSpy.mockClear();
+    warningSpy.mockClear();
+    debugSpy.mockClear();
+
+    issueContext = {
+      eventName: 'issues',
+      action: 'opened',
+      issue: {
+        number: 42,
+        title: 'Bug: something is broken',
+        body: 'Steps to reproduce...',
+        author: 'reporter',
+        url: 'https://github.com/owner/repo/issues/42',
+        state: 'open',
+      },
+      hasAsanaTasks: false,
+    };
+  });
+
+  test('matches issues event', () => {
+    const condition: Condition = { event: 'issues' };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('does not match pull_request condition against issues event', () => {
+    const condition: Condition = { event: 'pull_request' };
+    expect(matchesCondition(condition, issueContext)).toBe(false);
+  });
+
+  test('matches issues event with action', () => {
+    const condition: Condition = { event: 'issues', action: 'opened' };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('does not match when action differs', () => {
+    const condition: Condition = { event: 'issues', action: 'closed' };
+    expect(matchesCondition(condition, issueContext)).toBe(false);
+  });
+
+  test('matches issues event with array of actions', () => {
+    const condition: Condition = { event: 'issues', action: ['opened', 'reopened'] };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('matches issue author', () => {
+    const condition: Condition = { event: 'issues', author: 'reporter' };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('does not match wrong author', () => {
+    const condition: Condition = { event: 'issues', author: 'other' };
+    expect(matchesCondition(condition, issueContext)).toBe(false);
+  });
+
+  test('matches author array including issue author', () => {
+    const condition: Condition = { event: 'issues', author: ['reporter', 'admin'] };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('matches has_labels for issue labels', () => {
+    issueContext = { ...issueContext, labels: ['bug', 'help wanted'] };
+    const condition: Condition = { event: 'issues', has_labels: 'bug' };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('does not match has_labels when issue has no matching label', () => {
+    issueContext = { ...issueContext, labels: ['enhancement'] };
+    const condition: Condition = { event: 'issues', has_labels: 'bug' };
+    expect(matchesCondition(condition, issueContext)).toBe(false);
+  });
+
+  test('matches has_asana_tasks: false for issue without Asana links', () => {
+    const condition: Condition = { event: 'issues', has_asana_tasks: false };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+
+  test('does not match merged condition for issues event (PR-only condition)', () => {
+    const condition: Condition = { event: 'issues', merged: false };
+    expect(matchesCondition(condition, issueContext)).toBe(false);
+  });
+
+  test('does not match draft condition for issues event (PR-only condition)', () => {
+    const condition: Condition = { event: 'issues', draft: false };
+    expect(matchesCondition(condition, issueContext)).toBe(false);
+  });
+
+  test('label condition matches from labeled event', () => {
+    issueContext = { ...issueContext, label: { name: 'bug' } };
+    const condition: Condition = { event: 'issues', label: 'bug' };
+    expect(matchesCondition(condition, issueContext)).toBe(true);
+  });
+});
+
+describe('executeRules - issues event', () => {
+  let issueContext: RuleContext;
+
+  beforeEach(() => {
+    infoSpy.mockClear();
+    errorSpy.mockClear();
+    warningSpy.mockClear();
+    debugSpy.mockClear();
+
+    issueContext = {
+      eventName: 'issues',
+      action: 'opened',
+      issue: {
+        number: 42,
+        title: 'Bug: something is broken',
+        body: 'Steps to reproduce...',
+        author: 'reporter',
+        url: 'https://github.com/owner/repo/issues/42',
+        state: 'open',
+      },
+      hasAsanaTasks: false,
+    };
+  });
+
+  test('evaluates issue template variables', () => {
+    const rules: Rule[] = [
+      {
+        when: { event: 'issues', has_asana_tasks: false },
+        then: {
+          create_task: {
+            project: '111222333',
+            workspace: '444555666',
+            title: 'GH Issue #{{issue.number}}: {{issue.title}}',
+          },
+        },
+      },
+    ];
+
+    const { taskCreationSpecs } = executeRules(rules, issueContext);
+
+    expect(taskCreationSpecs).toHaveLength(1);
+    expect(taskCreationSpecs[0]!.evaluatedTitle).toBe('GH Issue #42: Bug: something is broken');
+  });
+
+  test('issue author is accessible in templates', () => {
+    const rules: Rule[] = [
+      {
+        when: { event: 'issues' },
+        then: { update_fields: { '1234': '{{issue.author}}' } },
+      },
+    ];
+
+    // has_asana_tasks: true required for update_fields — adjust context
+    const ctx = { ...issueContext, hasAsanaTasks: true };
+    const { fieldUpdates } = executeRules(rules, ctx);
+
+    expect(fieldUpdates.get('1234')).toBe('reporter');
+  });
+
+  test('issue url is accessible in templates', () => {
+    const rules: Rule[] = [
+      {
+        when: { event: 'issues' },
+        then: { update_fields: { '9999': '{{issue.url}}' } },
+      },
+    ];
+
+    const ctx = { ...issueContext, hasAsanaTasks: true };
+    const { fieldUpdates } = executeRules(rules, ctx);
+
+    expect(fieldUpdates.get('9999')).toBe('https://github.com/owner/repo/issues/42');
+  });
+
+  test('PR rules do not fire on issues event', () => {
+    const rules: Rule[] = [
+      {
+        when: { event: 'pull_request', action: 'opened' },
+        then: { update_fields: { '1234': 'In Review' } },
+      },
+    ];
+
+    const ctx = { ...issueContext, hasAsanaTasks: true };
+    const { fieldUpdates } = executeRules(rules, ctx);
+
+    expect(fieldUpdates.size).toBe(0);
+  });
+});
+
+describe('buildRuleContext - issues event', () => {
+  beforeEach(() => {
+    infoSpy.mockClear();
+    errorSpy.mockClear();
+    warningSpy.mockClear();
+    debugSpy.mockClear();
+  });
+
+  const makeIssuePayload = (overrides: Record<string, unknown> = {}) => ({
+    eventName: 'issues' as const,
+    payload: {
+      action: 'opened',
+      issue: {
+        number: 42,
+        title: 'Bug: something is broken',
+        body: 'Steps to reproduce...',
+        user: { login: 'reporter' },
+        assignee: null,
+        html_url: 'https://github.com/owner/repo/issues/42',
+        state: 'open',
+        labels: [{ name: 'bug' }, { name: 'help wanted' }],
+        ...overrides,
+      },
+    },
+  });
+
+  test('builds issue context from issues payload', () => {
+    const ctx = buildRuleContext(makeIssuePayload(), undefined, false);
+
+    expect(ctx.eventName).toBe('issues');
+    expect(ctx.action).toBe('opened');
+    expect(ctx.issue).toBeDefined();
+    expect(ctx.issue!.number).toBe(42);
+    expect(ctx.issue!.title).toBe('Bug: something is broken');
+    expect(ctx.issue!.author).toBe('reporter');
+    expect(ctx.issue!.state).toBe('open');
+    expect(ctx.issue!.url).toBe('https://github.com/owner/repo/issues/42');
+    expect(ctx.pr).toBeUndefined();
+  });
+
+  test('extracts labels from issue payload', () => {
+    const ctx = buildRuleContext(makeIssuePayload(), undefined, false);
+
+    expect(ctx.labels).toEqual(['bug', 'help wanted']);
+  });
+
+  test('sets hasAsanaTasks from caller', () => {
+    const ctx = buildRuleContext(makeIssuePayload(), undefined, true);
+    expect(ctx.hasAsanaTasks).toBe(true);
+  });
+
+  test('includes assignee when present', () => {
+    const ctx = buildRuleContext(
+      makeIssuePayload({ assignee: { login: 'maintainer' } }),
+      undefined,
+      false
+    );
+    expect(ctx.issue!.assignee).toBe('maintainer');
+  });
+
+  test('sets assignee to undefined when null', () => {
+    const ctx = buildRuleContext(makeIssuePayload({ assignee: null }), undefined, false);
+    expect(ctx.issue!.assignee).toBeUndefined();
+  });
+
+  test('handles empty issue body', () => {
+    const ctx = buildRuleContext(makeIssuePayload({ body: null }), undefined, false);
+    expect(ctx.issue!.body).toBe('');
+  });
+
+  test('extracts label from labeled event', () => {
+    const payload = {
+      ...makeIssuePayload(),
+      payload: {
+        ...makeIssuePayload().payload,
+        label: { name: 'critical' },
+      },
+    };
+    const ctx = buildRuleContext(payload, undefined, false);
+    expect(ctx.label).toEqual({ name: 'critical' });
+  });
+
+  test('throws for unsupported event', () => {
+    expect(() =>
+      buildRuleContext({ eventName: 'push', payload: {} }, undefined, false)
+    ).toThrow('Unsupported event: push');
+  });
+
+  test('throws when issue missing from issues payload', () => {
+    expect(() =>
+      buildRuleContext({ eventName: 'issues', payload: { action: 'opened' } }, undefined, false)
+    ).toThrow('No issue in GitHub payload');
   });
 });

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -89,6 +89,7 @@ export default defineConfig({
             { text: 'Basic Status Update', link: '/examples/basic-status-update' },
             { text: 'Mark Complete on Merge', link: '/examples/mark-complete-on-merge' },
             { text: 'Bot Task Creation', link: '/examples/bot-task-creation' },
+            { text: 'Issue Task Creation', link: '/examples/issue-task-creation' },
             { text: 'User Assigned Tasks', link: '/examples/user-assigned-tasks' },
             { text: 'Build Label Automation', link: '/examples/build-label-automation' },
             { text: 'Multi-Condition Filtering', link: '/examples/multi-condition-filtering' },

--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -137,7 +137,7 @@ See [mark_complete reference](/reference/actions/mark-complete).
 
 ## attach_pr_to_tasks
 
-Link PR to Asana tasks via GitHub integration.
+Link PR to Asana tasks via GitHub integration. **Pull request events only.**
 
 ### Basic Usage
 
@@ -166,6 +166,10 @@ Requires `integration_secret` input configured:
     github_token: ${{ github.token }}
     integration_secret: ${{ secrets.ASANA_INTEGRATION_SECRET }}
 ```
+
+::: warning PR only
+`attach_pr_to_tasks` is not supported for `issues` events. The Asana-GitHub integration is PR-specific. Using it in an issue rule logs a warning and skips the attachment.
+:::
 
 Creates integration attachment with live PR status in Asana. Automatically deduplicates.
 
@@ -214,9 +218,9 @@ See [post_pr_comment reference](/reference/actions/post-comment).
 
 ## create_task
 
-Create new Asana task (requires `has_asana_tasks: false`).
+Create new Asana task (requires `has_asana_tasks: false`). Works for both `pull_request` and `issues` events.
 
-### Minimal
+### From a PR
 
 ```yaml
 when:
@@ -229,7 +233,22 @@ then:
     title: '{{pr.title}}'
 ```
 
-### Complete
+### From a GitHub Issue
+
+```yaml
+when:
+  event: issues
+  action: opened
+  has_asana_tasks: false
+then:
+  create_task:
+    project: '1234567890'
+    workspace: '0987654321'
+    title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+    notes: '{{issue.body}}'
+```
+
+### Complete (PR)
 
 ```yaml
 then:
@@ -319,8 +338,9 @@ then:
 
 ### Available Context
 
-- **pr.*** - PR data (number, title, body, author, etc.)
-- **event.*** - Event data (name, action)
+- **pr.*** - PR data (number, title, body, author, etc.) — `pull_request` events only
+- **issue.*** - Issue data (number, title, body, author, etc.) — `issues` events only
+- **event.*** - Event data (name, action) — always available
 - **label.*** - Label data (when label condition matches)
 - **tasks*** - Task data (in post_pr_comment only)
 - **summary.*** - Summary data (in post_pr_comment only)

--- a/docs/concepts/conditions.md
+++ b/docs/concepts/conditions.md
@@ -1,6 +1,6 @@
 # Conditions
 
-When rules trigger based on GitHub events and PR state.
+When rules trigger based on GitHub events and PR or issue state.
 
 ## Overview
 
@@ -10,8 +10,8 @@ Conditions define when a rule should execute. They appear in the `when` block an
 when:
   event: pull_request      # Required
   action: opened           # Optional
-  merged: true             # Optional
-  draft: false             # Optional
+  merged: true             # Optional (PR only)
+  draft: false             # Optional (PR only)
   # All must match
 ```
 
@@ -54,7 +54,7 @@ See [action reference](/reference/conditions/action).
 
 ### merged
 
-Filter by merge status:
+Filter by PR merge status. **Pull request events only** — never matches for `issues` events.
 
 ```yaml
 when:
@@ -74,7 +74,7 @@ See [merged reference](/reference/conditions/merged).
 
 ### draft
 
-Filter by draft status:
+Filter by PR draft status. **Pull request events only** — never matches for `issues` events.
 
 ```yaml
 when:
@@ -128,12 +128,18 @@ See [has_asana_tasks reference](/reference/conditions/has-asana-tasks).
 
 ### author
 
-Filter by PR author username:
+Filter by author username. Works for both PR and issue events.
 
 ```yaml
 when:
   event: pull_request
   author: dependabot[bot]  # Single author
+```
+
+```yaml
+when:
+  event: issues
+  author: reporter-username  # Issue reporter
 ```
 
 Supports arrays:
@@ -281,6 +287,23 @@ when:
 then:
   update_fields:
     '1234567890': '0987654321'  # "In Review"
+```
+
+### GitHub Issues
+
+Create an Asana task when an issue is opened:
+
+```yaml
+when:
+  event: issues
+  action: opened
+  has_asana_tasks: false
+then:
+  create_task:
+    project: '1234567890'
+    workspace: '0987654321'
+    title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+    notes: '{{issue.body}}'
 ```
 
 ## Validation Rules

--- a/docs/concepts/templates.md
+++ b/docs/concepts/templates.md
@@ -44,7 +44,7 @@ notes: 'Event: {{event.name}} - {{event.action}}'
 
 ### PR Data
 
-Available in all templates:
+Available in `pull_request` event templates:
 
 ```handlebars
 {{pr.number}}      # 123
@@ -59,16 +59,32 @@ Available in all templates:
 {{pr.head_ref}}    # "feature-branch"
 ```
 
-### Event Data
+### Issue Data
+
+Available in `issues` event templates:
 
 ```handlebars
-{{event.name}}     # "pull_request"
-{{event.action}}   # "opened"
+{{issue.number}}   # 42
+{{issue.title}}    # "Bug: login fails"
+{{issue.body}}     # Full issue description
+{{issue.author}}   # "reporter"
+{{issue.assignee}} # "maintainer" (or empty if unassigned)
+{{issue.url}}      # "https://github.com/..."
+{{issue.state}}    # "open" or "closed"
+```
+
+### Event Data
+
+Always available:
+
+```handlebars
+{{event.name}}     # "pull_request" or "issues"
+{{event.action}}   # "opened", "closed", "labeled", etc.
 ```
 
 ### Label Data
 
-Only available when `label` condition matches:
+Only available when `action: labeled` or `action: unlabeled`:
 
 ```handlebars
 {{label.name}}     # "ready-for-qa"

--- a/docs/examples/issue-task-creation.md
+++ b/docs/examples/issue-task-creation.md
@@ -1,0 +1,222 @@
+# Issue Task Creation
+
+Automatically create Asana tasks when GitHub issues are opened.
+
+## Use Case
+
+When your team reports bugs or feature requests as GitHub issues, you want a corresponding Asana task created automatically — so nothing falls through the cracks between GitHub and Asana.
+
+## Minimal Example
+
+Create an Asana task for every new issue:
+
+```yaml
+rules:
+  - when:
+      event: issues
+      action: opened
+      has_asana_tasks: false
+    then:
+      create_task:
+        project: '1234567890'    # Your project GID
+        workspace: '0987654321'  # Your workspace GID
+        title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+```
+
+**What happens:**
+1. A GitHub issue is opened
+2. The action creates an Asana task titled `GH Issue #42: Bug: login fails`
+3. The Asana task URL is appended to the issue body so there's a permanent link back
+
+## With Full Description
+
+Include the issue body so the Asana task has the full context:
+
+```yaml
+rules:
+  - when:
+      event: issues
+      action: opened
+      has_asana_tasks: false
+    then:
+      create_task:
+        project: '1234567890'
+        workspace: '0987654321'
+        title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+        notes: |
+          {{issue.body}}
+
+          ---
+          Reported by: @{{issue.author}}
+          GitHub Issue: {{issue.url}}
+```
+
+## With Initial Custom Fields
+
+Set a status or category field when the task is created:
+
+```yaml
+rules:
+  - when:
+      event: issues
+      action: opened
+      has_asana_tasks: false
+    then:
+      create_task:
+        project: '1234567890'
+        workspace: '0987654321'
+        section: '1111111111'     # "Incoming" section GID
+        title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+        notes: '{{issue.body}}'
+        initial_fields:
+          '2222222222': '3333333333'  # Status → "Needs Triage"
+```
+
+## With User Assignment
+
+Assign the task to a specific Asana user based on who opened the issue:
+
+```yaml
+# In workflow inputs:
+user_mappings: |
+  alice: 1234567890
+  bob: 0987654321
+
+rules:
+  - when:
+      event: issues
+      action: opened
+      has_asana_tasks: false
+    then:
+      create_task:
+        project: '1234567890'
+        workspace: '0987654321'
+        title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+        assignee: '{{map_github_to_asana issue.author}}'
+```
+
+## Filter by Label
+
+Only create tasks for issues with a specific label (e.g., `bug`):
+
+```yaml
+rules:
+  - when:
+      event: issues
+      action: labeled
+      label: bug
+      has_asana_tasks: false
+    then:
+      create_task:
+        project: '1234567890'
+        workspace: '0987654321'
+        section: '4444444444'  # "Bugs" section GID
+        title: '[Bug] {{issue.title}}'
+        notes: '{{issue.body}}'
+        initial_fields:
+          '5555555555': '6666666666'  # Priority → "High"
+```
+
+## Combined PR and Issue Workflow
+
+A single workflow file that handles both PRs and issues:
+
+```yaml
+# .github/workflows/asana-sync.yml
+on:
+  pull_request:
+    types: [opened, closed, labeled, reopened, ready_for_review]
+  issues:
+    types: [opened, labeled]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: planningcenter/asana-github-sync@main
+        with:
+          asana_token: ${{ secrets.ASANA_TOKEN }}
+          github_token: ${{ github.token }}
+          rules: |
+            rules:
+              # PR: update status when opened for review
+              - when:
+                  event: pull_request
+                  action: [opened, reopened]
+                  draft: false
+                then:
+                  attach_pr_to_tasks: true
+                  update_fields:
+                    '1111111111': 'In Review'
+
+              # PR: mark complete when merged
+              - when:
+                  event: pull_request
+                  action: closed
+                  merged: true
+                then:
+                  mark_complete: true
+                  update_fields:
+                    '1111111111': 'Done'
+
+              # Issue: create Asana task for new issues
+              - when:
+                  event: issues
+                  action: opened
+                  has_asana_tasks: false
+                then:
+                  create_task:
+                    project: '2222222222'
+                    workspace: '3333333333'
+                    title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+                    notes: '{{issue.body}}'
+                    initial_fields:
+                      '4444444444': '5555555555'  # Status → "Needs Triage"
+```
+
+## Workflow Configuration
+
+Add `issues` to your workflow's `on:` block:
+
+```yaml
+on:
+  issues:
+    types: [opened]          # Minimal: just new issues
+```
+
+Or with more actions:
+
+```yaml
+on:
+  issues:
+    types: [opened, labeled]  # Create on open or label
+```
+
+::: warning Avoid `edited` with `has_asana_tasks: false`
+After the action creates a task, it appends the Asana link to the issue body. This triggers an `issues.edited` event. If you have a rule for `action: edited` with `has_asana_tasks: false`, it will loop infinitely.
+
+Always use `action: opened` (or `labeled`) for task creation rules, never `action: edited`.
+:::
+
+## Available Template Variables
+
+In `issues` event rules, use `{{issue.*}}` variables:
+
+| Variable | Example |
+|----------|---------|
+| `{{issue.number}}` | `42` |
+| `{{issue.title}}` | `Bug: login fails` |
+| `{{issue.body}}` | Full issue description |
+| `{{issue.author}}` | `reporter-username` |
+| `{{issue.assignee}}` | `maintainer` (if set) |
+| `{{issue.url}}` | `https://github.com/...` |
+| `{{issue.state}}` | `open` |
+
+See [Context Variables](/reference/context-variables) for the complete reference.
+
+## See Also
+
+- [create_task reference](/reference/actions/create-task) - All task creation options
+- [has_asana_tasks reference](/reference/conditions/has-asana-tasks) - Required condition
+- [Context Variables](/reference/context-variables) - All `issue.*` template variables
+- [Bot Task Creation](/examples/bot-task-creation) - Similar pattern for Dependabot PRs

--- a/docs/reference/actions/attach-pr-to-tasks.md
+++ b/docs/reference/actions/attach-pr-to-tasks.md
@@ -10,6 +10,10 @@ Attach GitHub pull request to existing Asana tasks via the GitHub integration.
 
 The `attach_pr_to_tasks` action links the current GitHub PR to existing Asana tasks through the Asana-GitHub integration. This creates a proper integration attachment with live PR status in Asana, rather than just a plain URL link.
 
+::: warning Pull request events only
+`attach_pr_to_tasks` is **not supported for `issues` events**. The Asana-GitHub integration is designed specifically for pull requests. Using this action in an `issues` rule logs a warning and skips the step.
+:::
+
 ::: warning Requirements
 - Requires `has_asana_tasks: true` (default)
 - Requires `integration_secret` input to be configured

--- a/docs/reference/context-variables.md
+++ b/docs/reference/context-variables.md
@@ -4,11 +4,21 @@ Template variables available in Handlebars expressions.
 
 ## Overview
 
-Context variables provide access to PR data, event information, and other runtime values. Use these in any template string throughout your rules.
+Context variables provide access to PR or issue data, event information, and other runtime values. Use these in any template string throughout your rules.
+
+The available variables depend on the event type:
+
+| Variable group | `pull_request` | `issues` |
+|----------------|:--------------:|:--------:|
+| `pr.*`         | ✅ | — |
+| `issue.*`      | — | ✅ |
+| `event.*`      | ✅ | ✅ |
+| `label.*`      | ✅ (labeled events) | ✅ (labeled events) |
+| `comments`     | ✅ (on-demand) | ✅ (on-demand) |
 
 ## pr (Pull Request)
 
-Pull request information. Always available in `pull_request` events.
+Pull request information. Available in `pull_request` events only.
 
 | Variable | Type | Description | Example |
 |----------|------|-------------|---------|
@@ -33,6 +43,37 @@ update_fields:
 post_pr_comment: |
   PR #{{pr.number}} by @{{pr.author}}
   {{pr.url}}
+```
+
+## issue (GitHub Issue)
+
+Issue information. Available in `issues` events only.
+
+| Variable | Type | Description | Example |
+|----------|------|-------------|---------|
+| `issue.number` | number | Issue number | `42` |
+| `issue.title` | string | Issue title | `"Bug: login fails"` |
+| `issue.body` | string | Issue description | Full text |
+| `issue.author` | string | Issue author username | `"reporter"` |
+| `issue.assignee` | string? | Issue assignee username (optional) | `"maintainer"` |
+| `issue.url` | string | Issue URL | `https://github.com/...` |
+| `issue.state` | string | Issue state | `"open"` / `"closed"` |
+| `issue.labels` | string[]? | All label names on the issue | `["bug", "help wanted"]` |
+
+### Examples
+
+```yaml
+create_task:
+  title: 'GH Issue #{{issue.number}}: {{issue.title}}'
+  notes: |
+    Reported by: {{issue.author}}
+    {{issue.url}}
+
+    {{issue.body}}
+
+post_pr_comment: |
+  Issue #{{issue.number}} by @{{issue.author}}
+  {{issue.url}}
 ```
 
 ## event
@@ -68,7 +109,7 @@ post_pr_comment: |
 
 ## comments
 
-All PR comments concatenated.
+All comments (PR or issue) concatenated.
 
 ::: warning Important
 Comments are **only fetched when you use `extract_from_comments`** helper. This is the only time the `comments` variable will be available. The action fetches comments on-demand to avoid unnecessary API calls.
@@ -254,13 +295,15 @@ Use `or` helper for defaults:
 
 ### create_task
 
-All variables available:
-- `pr.*`, `event.*`, `label.*` (if applicable), `comments` (if available)
+All variables for the triggering event available:
+- PR events: `pr.*`, `event.*`, `label.*` (if applicable), `comments` (if available)
+- Issue events: `issue.*`, `event.*`, `label.*` (if applicable), `comments` (if available)
 
 ### update_fields
 
-All variables available:
-- `pr.*`, `event.*`, `label.*`, `comments`
+All variables for the triggering event available:
+- PR events: `pr.*`, `event.*`, `label.*`, `comments`
+- Issue events: `issue.*`, `event.*`, `label.*`, `comments`
 
 ### mark_complete
 
@@ -268,12 +311,12 @@ No template evaluation (boolean value only).
 
 ### post_pr_comment
 
-All variables plus task results (if using advanced templates).
+All variables plus task results (if using advanced templates). Works for both PR and issue events.
 
 ## See Also
 
 - [Template Helpers](/reference/helpers/) - Functions for working with variables
-- [extract_from_body](/reference/helpers/extraction#extract_from_body) - Extract from pr.body
-- [clean_title](/reference/helpers/text-processing#clean_title) - Clean pr.title
-- [map_github_to_asana](/reference/helpers/user-mapping) - Map pr.author
+- [extract_from_body](/reference/helpers/extraction#extract_from_body) - Extract from body (PR or issue)
+- [clean_title](/reference/helpers/text-processing#clean_title) - Clean title text
+- [map_github_to_asana](/reference/helpers/user-mapping) - Map GitHub users to Asana
 - [Template System](/concepts/templates) - Handlebars overview

--- a/src/expression/context.ts
+++ b/src/expression/context.ts
@@ -19,6 +19,20 @@ export interface PRContext {
 }
 
 /**
+ * Issue context available in templates
+ */
+export interface IssueContext {
+  number: number;
+  title: string;
+  body: string;
+  author: string;
+  assignee?: string;
+  url: string;
+  state: string;
+  labels?: string[];
+}
+
+/**
  * Event context available in templates
  */
 export interface EventContext {
@@ -37,10 +51,11 @@ export interface LabelContext {
  * Complete Handlebars context for template evaluation
  */
 export interface HandlebarsContext {
-  pr: PRContext;
+  pr?: PRContext;    // Present for pull_request events
+  issue?: IssueContext; // Present for issues events
   event: EventContext;
   label?: LabelContext;
-  comments?: string; // All PR comments concatenated (if fetched)
+  comments?: string; // All comments concatenated (if fetched)
   userMappings?: Record<string, string>; // GitHub username → Asana user GID mapping
 }
 
@@ -55,11 +70,12 @@ export interface TaskResult {
 }
 
 /**
- * Comment context for post-execution PR comment templates
+ * Comment context for post-execution PR/issue comment templates
  * Includes task results and update summary
  */
 export interface CommentContext {
-  pr: PRContext;
+  pr?: PRContext;
+  issue?: IssueContext;
   event: EventContext;
   comments?: string;
   tasks: TaskResult[];

--- a/src/expression/helpers.ts
+++ b/src/expression/helpers.ts
@@ -38,15 +38,15 @@ function extractFromText(pattern: string, text: string): string {
  * Call this once at startup before evaluating templates
  */
 export function registerHelpers(): void {
-  // Helper: Extract from PR body
+  // Helper: Extract from body (PR or issue)
   Handlebars.registerHelper('extract_from_body', function (this: HandlebarsContext, pattern: string) {
-    const body = this.pr?.body || '';
+    const body = this.pr?.body || this.issue?.body || '';
     return extractFromText(pattern, body);
   });
 
-  // Helper: Extract from PR title
+  // Helper: Extract from title (PR or issue)
   Handlebars.registerHelper('extract_from_title', function (this: HandlebarsContext, pattern: string) {
-    const title = this.pr?.title || '';
+    const title = this.pr?.title || this.issue?.title || '';
     return extractFromText(pattern, title);
   });
 


### PR DESCRIPTION
## Summary

- Extends the action to handle `issues` events alongside `pull_request` events
- Rules can now create or update Asana tasks in response to GitHub issue lifecycle events (opened, closed, labeled, etc.)
- `issue.*` template variables available in all rule templates for issues events (`issue.number`, `issue.title`, `issue.body`, `issue.author`, `issue.url`, `issue.state`)
- `merged`/`draft` conditions are silently PR-only (never match on issue rules); `author`, `has_labels`, `has_asana_tasks` work for both
- `attach_pr_to_tasks` logs a warning and skips for issues events (Asana integration is PR-specific)
- After task creation, the Asana link is appended to the issue body (same link-back behaviour as PRs)
- All existing PR behaviour is unchanged — fully backward compatible

## Example usage

```yaml
on:
  issues:
    types: [opened]

rules:
  - when:
      event: issues
      action: opened
      has_asana_tasks: false
    then:
      create_task:
        project: '1234567890'
        workspace: '0987654321'
        title: 'GH Issue #{{issue.number}}: {{issue.title}}'
        notes: '{{issue.body}}'
```

## Test plan

- [x] All 231 existing tests still pass (258 total with new tests)
- [x] 27 new tests covering `buildRuleContext` for issues, `matchesCondition` for issues, `executeRules` with issue template variables
- [x] TypeScript build clean (`tsc` no errors)
- [x] Docs updated: event reference, context variables, conditions/actions/templates concepts, `create-task` and `attach-pr-to-tasks` references, new Issue Task Creation example page

🤖 Generated with [Claude Code](https://claude.com/claude-code)