### PR TITLE
ci: Upgrade action runtime to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       contents: write
     steps:
       - id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@v3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
         run: bun run docs:build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist
 

--- a/action.yml
+++ b/action.yml
@@ -36,5 +36,5 @@ outputs:
     description: 'Number of tasks created'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

- Upgrade action runtime from Node 20 to Node 24 in action.yml ahead of the June 2, 2026 forced migration
- Bump dependabot/fetch-metadata v2 to v3 and actions/upload-pages-artifact v4 to v5 for Node 24 compatibility

## Context

GitHub is deprecating Node 20 for Actions runners ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Starting June 2, 2026, all actions will be forced to run on Node 24. Node 20 reaches EOL on April 30, 2026.

No dependency or build changes were needed — @actions/core and @actions/github are already compatible.

## Test plan

- [x] bun run all passes (format, lint, 290 tests, package)
